### PR TITLE
Add clip trimming

### DIFF
--- a/src/modules/recorder.module.ts
+++ b/src/modules/recorder.module.ts
@@ -334,11 +334,14 @@ async function handleTrimClip(clipName: string, start: number, end: number, text
         end = duration + end
     }
 
-    // reject if start > duration
+    // reject if start > duration or start < 0
+    if (start < 0) {
+        return await textChannel.send("Start time is before the beginning of the clip")
+    }
+
     if (start > duration) {
         return await textChannel.send(`Start time is after the end of the clip (${duration.toFixed(1)})`)
     }
-
 
     if (start >= end) {
         return await textChannel.send("Start time must be before end time.")

--- a/src/types/models/clip.ts
+++ b/src/types/models/clip.ts
@@ -8,6 +8,7 @@ export interface Clip {
     clipstart: number,
     clipend: number,
     participants: string[],
+    duration: number
 }
 
 /*
@@ -39,12 +40,17 @@ export function deleteClipByName(name: string): Promise<null> {
 }
 
 export function createClip(clip: Clip): Promise<null> {
-    return db.none('INSERT INTO Clips (id, time, name, url, clipstart, clipend, participants)' +
+    return db.none('INSERT INTO Clips (id, time, name, url, clipstart, clipend, participants, duration)' +
         'VALUES ($1, $2, $3, $4, $5, $6, $7)', 
         [clip.id, clip.time, clip.name, 
-        clip.url, clip.clipstart, clip.clipend, clip.participants])
+        clip.url, clip.clipstart, clip.clipend, clip.participants, clip.duration])
 }
 
 export function renameClip(oldName: string, newName: string): Promise<null> {
     return db.none('UPDATE Clips SET name = $1 WHERE name = $2', [newName, oldName])
+}
+
+export function trimClip(name: string, start: number, end: number): Promise<null> {
+    return db.none('UPDATE Clips SET clipstart = $2, clipend = $3 WHERE name = $1',
+        [name, start, end])
 }

--- a/src/utils/audiobuffer.ts
+++ b/src/utils/audiobuffer.ts
@@ -10,6 +10,18 @@ const MILLIS_PER_SECOND = 1000
 const INT_MAX = Math.pow(2, BIT_DEPTH - 1) - 1
 const INT_MIN = -Math.pow(2, BIT_DEPTH - 1)
 
+export function secondsToSampleAlignedOffset(seconds: number): number {
+    let ptr = Math.floor(seconds * SAMPLE_RATE * BYTES_PER_SAMPLE)
+    if (ptr % BYTES_PER_SAMPLE !== 0) {
+        ptr -= ptr % BYTES_PER_SAMPLE
+    }
+    return ptr
+}
+
+export function offsetToSeconds(offset: number): number {
+    return offset / BYTES_PER_SAMPLE / SAMPLE_RATE
+}
+
 export function timeToOffset(buffer: PCMBuffer, timeOffset: number): number {
     // get current time, modulo to length of buffer
     const now = new Date()


### PR DESCRIPTION
Adds a column to the `Clips` table - `duration`. This is the total byte length of the clip.

`!clip trim <name> <start> [end]`

`start` and `end` are expressed in seconds. If start or end is less than zero, it is interpreted as that many seconds before the end of the clip. If `end` is not given, it is assumed to be the end of the clip.

Command is rejected if:
* clip does not exist
* start > end
* start > duration