### PR TITLE
Add baltop and pay commands

### DIFF
--- a/src/modules/money.module.ts
+++ b/src/modules/money.module.ts
@@ -1,6 +1,6 @@
 import { BotModule } from "../types"
 import { getMoneyBalanceDao } from "../utils/model"
-import { User, Message, Client } from "discord.js"
+import { User, Message, Client, Channel } from "discord.js"
 import pgPromise from "pg-promise"
 
 const moneyBalanceDao = getMoneyBalanceDao()
@@ -19,6 +19,16 @@ async function printBalance(message: Message) {
         }
     } catch (error) {
         await moneyBalanceDao.initUser(author.id)
+        await printBalance(message)
+    }
+}
+
+async function handleMessage(message: Message) {
+    if (!message.content || !message.channel) {
+        return
+    }
+
+    if (message.content.startsWith("!money")) {
         await printBalance(message)
     }
 }

--- a/src/modules/money.module.ts
+++ b/src/modules/money.module.ts
@@ -1,7 +1,10 @@
 import { BotModule } from "../types"
 import { getMoneyBalanceDao } from "../utils/model"
-import { User, Message, Client, Channel } from "discord.js"
+import { User, Message, Client, TextChannel } from "discord.js"
+import { BALANCE_UNINITIALIZED_ERROR, LOW_BALANCE_ERROR } from "../types/models/moneybalance.dao"
 import pgPromise from "pg-promise"
+
+const MENTION_PATTERN = /<@!(\d+)>/
 
 const moneyBalanceDao = getMoneyBalanceDao()
 
@@ -23,21 +26,60 @@ async function printBalance(message: Message) {
     }
 }
 
+async function handlePay(sender: string, receiver: string, amount: number, channel: TextChannel) {
+    if (sender === receiver) {
+        return channel.send("You cannot send money to yourself.")
+    }
+    
+    if (isNaN(amount)) {
+        return channel.send("Please enter a number for the amount of money to send.")
+    }
+
+    if (amount <= 0) {
+        return channel.send("Amount of money to send must be positive.")
+    }
+
+    try {
+        await moneyBalanceDao.transfer(sender, receiver, amount)
+        return channel.send(`Successfully sent user :gem: **${amount}**.`)
+    } catch (err) {
+        if (err === BALANCE_UNINITIALIZED_ERROR) {
+            return channel.send("Your intended recipient does not have a balance set up. (have them run \`!money\`)")
+        } else if (err === LOW_BALANCE_ERROR) {
+            return channel.send("You do not have enough money to send.")
+        }
+    }
+}
+
 async function handleMessage(message: Message) {
-    if (!message.content || !message.channel) {
+    if (!message.content || !message.channel || !message.author) {
         return
     }
 
+    if (!(message.channel instanceof TextChannel)) {
+        return 
+    }
+
     if (message.content.startsWith("!money")) {
-        await printBalance(message)
+        return await printBalance(message)
+    }
+
+    // !pay <mentioned-user> <amount>
+    else if (message.content.startsWith("!pay")) {
+        const args = message.content.split(" ")
+        const sender: string = message.author.id
+        const receiverMatch: RegExpMatchArray | null = args[1].match(MENTION_PATTERN)
+        if (receiverMatch) {
+            const receiver = receiverMatch[1]
+            const amount = parseFloat(args[2])
+            return await handlePay(sender, receiver, amount, message.channel)
+        }
     }
 }
 
 export const MoneyModule: BotModule = (client: Client) => {
     console.log("Loaded MoneyModule")
     client.on("message", async message => {
-        if (message.content && message.content.startsWith("!money")) {
-            await printBalance(message)
-        }
+        await handleMessage(message)
     })
 }

--- a/src/modules/stocks.module.ts
+++ b/src/modules/stocks.module.ts
@@ -1,8 +1,8 @@
 import { BotModule } from "../types"
 import { Client, Message, TextChannel } from "discord.js"
 
-import { Shares, Transaction,
-    BALANCE_UNINITIALIZED_ERROR, LOW_BALANCE_ERROR, NOT_ENOUGH_SHARES_ERROR } from "../types/models/shares.dao"
+import { Shares, Transaction, NOT_ENOUGH_SHARES_ERROR } from "../types/models/shares.dao"
+import { BALANCE_UNINITIALIZED_ERROR, LOW_BALANCE_ERROR } from "../types/models/moneybalance.dao"
 import { getMoneyBalanceDao, getSharesDao } from "../utils/model"
 import { generateTable } from "../utils/table"
 

--- a/src/types/models/firestore/moneybalance.ts
+++ b/src/types/models/firestore/moneybalance.ts
@@ -6,6 +6,16 @@ function getBalance(user: string): Promise<MoneyBalance> {
     return getOne<MoneyBalance>(moneyRef, user)
 }
 
+async function getAllBalances(): Promise<Map<string, MoneyBalance>> {
+    const moneyRef = getFirestoreConnection().collection(MONEY_COLLECTION_NAME)
+    const snapshot = await moneyRef.get()
+    const res: Map<string, MoneyBalance> = new Map()
+    snapshot.forEach(doc => {
+        res.set(doc.id, doc.data() as MoneyBalance)
+    })
+    return res
+}
+
 async function initUser(user: string): Promise<void> {
     const moneyRef = getFirestoreConnection().collection(MONEY_COLLECTION_NAME)
     await moneyRef.doc(user).set({ id: user, amount: 10000 })
@@ -13,5 +23,6 @@ async function initUser(user: string): Promise<void> {
 
 export const MoneyBalanceFirestoreDao: MoneyBalanceDao = {
     getBalance,
+    getAllBalances,
     initUser
 }

--- a/src/types/models/firestore/moneybalance.ts
+++ b/src/types/models/firestore/moneybalance.ts
@@ -1,5 +1,6 @@
 import { getFirestoreConnection, getOne } from "../../../utils/db/firestore"
-import { MoneyBalance, MoneyBalanceDao, MONEY_COLLECTION_NAME } from '../moneybalance.dao'
+import { MoneyBalance, MoneyBalanceDao, MONEY_COLLECTION_NAME,
+    BALANCE_UNINITIALIZED_ERROR, LOW_BALANCE_ERROR } from '../moneybalance.dao'
 
 function getBalance(user: string): Promise<MoneyBalance> {
     const moneyRef = getFirestoreConnection().collection(MONEY_COLLECTION_NAME)
@@ -21,8 +22,32 @@ async function initUser(user: string): Promise<void> {
     await moneyRef.doc(user).set({ id: user, amount: 10000 })
 }
 
+async function transfer(from: string, to: string, amount: number): Promise<void> {
+    const db = getFirestoreConnection()
+    const fromDocRef = db.collection(MONEY_COLLECTION_NAME).doc(from)
+    const toDocRef = db.collection(MONEY_COLLECTION_NAME).doc(to)
+
+    await db.runTransaction(async (t) => {
+        const fromDoc = await t.get(fromDocRef)
+        const toDoc = await t.get(toDocRef)
+        if (!fromDoc.exists || !toDoc.exists) {
+            throw BALANCE_UNINITIALIZED_ERROR
+        }
+
+        const fromMoney: MoneyBalance = fromDoc.data() as MoneyBalance
+        const toMoney: MoneyBalance = toDoc.data() as MoneyBalance
+        if (fromMoney.amount < amount) {
+            throw LOW_BALANCE_ERROR
+        }
+
+        t.update(fromDocRef, { amount: fromMoney.amount - amount })
+        t.update(toDocRef, { amount: toMoney.amount + amount })
+    })
+}
+
 export const MoneyBalanceFirestoreDao: MoneyBalanceDao = {
     getBalance,
     getAllBalances,
-    initUser
+    initUser,
+    transfer
 }

--- a/src/types/models/firestore/shares.ts
+++ b/src/types/models/firestore/shares.ts
@@ -1,8 +1,10 @@
 import { getFirestoreConnection, getOne, find } from "../../../utils/db/firestore"
 import { Shares, Transaction, SharesDao, 
-    BALANCE_UNINITIALIZED_ERROR, LOW_BALANCE_ERROR, NOT_ENOUGH_SHARES_ERROR,
+    NOT_ENOUGH_SHARES_ERROR,
     SHARES_COLLECTION_NAME, TRANSACTION_COLLECTION_NAME } from "../shares.dao"
-import { MoneyBalance, MoneyBalanceDao, MONEY_COLLECTION_NAME } from '../moneybalance.dao'
+import { MoneyBalance, MoneyBalanceDao, 
+    BALANCE_UNINITIALIZED_ERROR, LOW_BALANCE_ERROR, 
+    MONEY_COLLECTION_NAME } from '../moneybalance.dao'
 
 function getSharesDocId(user: string, symbol: string): string {
     return user + '-' + symbol
@@ -44,72 +46,68 @@ async function buyShares(user: string, symbol: string, amount: number, price: nu
     const moneyDocRef = db.collection(MONEY_COLLECTION_NAME).doc(user)
     const transactionDocRef = db.collection(TRANSACTION_COLLECTION_NAME).doc(getTransactionDocId(user, symbol, time))
 
-    try {
-        const res: Transaction = await db.runTransaction(async (t) => {
-            const sharesDoc = await t.get(sharesDocRef)
-            const moneyDoc = await t.get(moneyDocRef)
-            // Throw error if user's moneybalance is not initialized
-            if (!moneyDoc.exists) {
-                throw { type: BALANCE_UNINITIALIZED_ERROR }
+    const res: Transaction = await db.runTransaction(async (t) => {
+        const sharesDoc = await t.get(sharesDocRef)
+        const moneyDoc = await t.get(moneyDocRef)
+        // Throw error if user's moneybalance is not initialized
+        if (!moneyDoc.exists) {
+            throw { type: BALANCE_UNINITIALIZED_ERROR }
+        }
+
+        const money: MoneyBalance = moneyDoc.data() as MoneyBalance
+        // Throw error if not enough money
+        if (money.amount < amount * price) {
+            throw {
+                type: LOW_BALANCE_ERROR,
+                balance: money.amount,
+                needed: amount * price
             }
+        }
 
-            const money: MoneyBalance = moneyDoc.data() as MoneyBalance
-            // Throw error if not enough money
-            if (money.amount < amount * price) {
-                throw {
-                    type: LOW_BALANCE_ERROR,
-                    balance: money.amount,
-                    needed: amount * price
-                }
-            }
+        const startBalance = money.amount
+        const endBalance = startBalance - amount * price
+        let startShares, endShares, startAvg, endAvg
 
-            const startBalance = money.amount
-            const endBalance = startBalance - amount * price
-            let startShares, endShares, startAvg, endAvg
+        // Update the shares ownership for the user
+        if (sharesDoc.exists) {
+            const shares: Shares = sharesDoc.data() as Shares
+            startShares = shares.amount
+            endShares = startShares + amount
+            startAvg = shares.averagePrice
+            endAvg = (startAvg * startShares + price * amount) / endShares
 
-            // Update the shares ownership for the user
-            if (sharesDoc.exists) {
-                const shares: Shares = sharesDoc.data() as Shares
-                startShares = shares.amount
-                endShares = startShares + amount
-                startAvg = shares.averagePrice
-                endAvg = (startAvg * startShares + price * amount) / endShares
+            t.update(sharesDocRef, {
+                amount: endShares,
+                averagePrice: endAvg
+            })
+        } else {
+            startShares = 0
+            endShares = amount
+            startAvg = 0
+            endAvg = price
+            t.set(sharesDocRef, { user: user, symbol: symbol, amount: amount, averagePrice: price })
+        }
 
-                t.update(sharesDocRef, {
-                    amount: endShares,
-                    averagePrice: endAvg
-                })
-            } else {
-                startShares = 0
-                endShares = amount
-                startAvg = 0
-                endAvg = price
-                t.set(sharesDocRef, { user: user, symbol: symbol, amount: amount, averagePrice: price })
-            }
+        // Update the money balance for the user
+        t.update(moneyDocRef, { amount: endBalance })
 
-            // Update the money balance for the user
-            t.update(moneyDocRef, { amount: endBalance })
-
-            // Write a shares transaction and return it
-            const sharesTransaction: Transaction = {
-                user,
-                symbol,
-                time,
-                price,
-                startBalance,
-                endBalance,
-                startShares,
-                endShares,
-                startAvg,
-                endAvg
-            }
-            t.set(transactionDocRef, sharesTransaction)
-            return sharesTransaction
-        })
-        return res
-    } catch (e) {
-        throw e
-    }
+        // Write a shares transaction and return it
+        const sharesTransaction: Transaction = {
+            user,
+            symbol,
+            time,
+            price,
+            startBalance,
+            endBalance,
+            startShares,
+            endShares,
+            startAvg,
+            endAvg
+        }
+        t.set(transactionDocRef, sharesTransaction)
+        return sharesTransaction
+    })
+    return res
 }
 
 async function sellShares(user: string, symbol: string, amount: number, price: number): Promise<Transaction> {
@@ -119,66 +117,62 @@ async function sellShares(user: string, symbol: string, amount: number, price: n
     const moneyDocRef = db.collection(MONEY_COLLECTION_NAME).doc(user)
     const transactionDocRef = db.collection(TRANSACTION_COLLECTION_NAME).doc(getTransactionDocId(user, symbol, time))
 
-    try {
-        const res: Transaction = await db.runTransaction(async (t) => {
-            const sharesDoc = await t.get(sharesDocRef)
-            const moneyDoc = await t.get(moneyDocRef)
-            // Throw error if user's moneybalance is not initialized
-            if (!moneyDoc.exists) {
-                throw { type: BALANCE_UNINITIALIZED_ERROR }
+    const res: Transaction = await db.runTransaction(async (t) => {
+        const sharesDoc = await t.get(sharesDocRef)
+        const moneyDoc = await t.get(moneyDocRef)
+        // Throw error if user's moneybalance is not initialized
+        if (!moneyDoc.exists) {
+            throw { type: BALANCE_UNINITIALIZED_ERROR }
+        }
+
+        // Throw error if shares doc does not exist
+        if (!sharesDoc.exists) {
+            throw {
+                type: NOT_ENOUGH_SHARES_ERROR,
+                amount: 0
             }
+        }
 
-            // Throw error if shares doc does not exist
-            if (!sharesDoc.exists) {
-                throw {
-                    type: NOT_ENOUGH_SHARES_ERROR,
-                    amount: 0
-                }
+        // Throw error if user does not own enough shares
+        const shares: Shares = sharesDoc.data() as Shares
+        if (shares.amount < amount) {
+            throw {
+                type: NOT_ENOUGH_SHARES_ERROR,
+                amount: shares.amount
             }
+        }
 
-            // Throw error if user does not own enough shares
-            const shares: Shares = sharesDoc.data() as Shares
-            if (shares.amount < amount) {
-                throw {
-                    type: NOT_ENOUGH_SHARES_ERROR,
-                    amount: shares.amount
-                }
-            }
+        const money: MoneyBalance = moneyDoc.data() as MoneyBalance
+        const startBalance = money.amount
+        const endBalance = startBalance + amount * price
+        const startShares = shares.amount
+        const endShares = startShares - amount
+        const startAvg = shares.averagePrice
+        const endAvg = shares.averagePrice
 
-            const money: MoneyBalance = moneyDoc.data() as MoneyBalance
-            const startBalance = money.amount
-            const endBalance = startBalance + amount * price
-            const startShares = shares.amount
-            const endShares = startShares - amount
-            const startAvg = shares.averagePrice
-            const endAvg = shares.averagePrice
+        // Update the shares ownership for the user
+        t.update(sharesDocRef, { amount: endShares })
 
-            // Update the shares ownership for the user
-            t.update(sharesDocRef, { amount: endShares })
+        // Update the money balance for the user
+        t.update(moneyDocRef, { amount: endBalance })
 
-            // Update the money balance for the user
-            t.update(moneyDocRef, { amount: endBalance })
-
-            // Write a shares transaction and return it
-            const sharesTransaction: Transaction = {
-                user,
-                symbol,
-                time,
-                price,
-                startBalance,
-                endBalance,
-                startShares,
-                endShares,
-                startAvg,
-                endAvg
-            }
-            t.set(transactionDocRef, sharesTransaction)
-            return sharesTransaction
-        })
-        return res
-    } catch (e) {
-        throw e
-    }
+        // Write a shares transaction and return it
+        const sharesTransaction: Transaction = {
+            user,
+            symbol,
+            time,
+            price,
+            startBalance,
+            endBalance,
+            startShares,
+            endShares,
+            startAvg,
+            endAvg
+        }
+        t.set(transactionDocRef, sharesTransaction)
+        return sharesTransaction
+    })
+    return res
 }
 
 export const SharesFirestoreDao: SharesDao = {

--- a/src/types/models/firestore/shares.ts
+++ b/src/types/models/firestore/shares.ts
@@ -12,6 +12,21 @@ function getTransactionDocId(user: string, symbol: string, time: Date): string {
     return user + '-' + symbol + '-' + time.getTime()
 }
 
+async function getAllShares(): Promise<Map<string, Shares[]>> {
+    const sharesRef = getFirestoreConnection().collection(SHARES_COLLECTION_NAME)
+    const snapshot = await sharesRef.get()
+    const res: Map<string, Shares[]> = new Map()
+    snapshot.forEach(doc => {
+        const shares = doc.data() as Shares
+        if (res.has(shares.user)) {
+            res.get(shares.user)!.push(shares)
+        } else {
+            res.set(shares.user, [shares])
+        }
+    })
+    return res
+}
+
 function getSharesByUser(user: string): Promise<Array<Shares>> {
     const sharesRef = getFirestoreConnection().collection(SHARES_COLLECTION_NAME)
     return find<Shares>(sharesRef, 'user', '==', user)
@@ -167,6 +182,7 @@ async function sellShares(user: string, symbol: string, amount: number, price: n
 }
 
 export const SharesFirestoreDao: SharesDao = {
+    getAllShares,
     getSharesByUser,
     getSharesByUserAndSymbol,
     buyShares,

--- a/src/types/models/moneybalance.dao.ts
+++ b/src/types/models/moneybalance.dao.ts
@@ -7,5 +7,6 @@ export const MONEY_COLLECTION_NAME = 'moneybalance'
 
 export type MoneyBalanceDao = {
     getBalance: (user: string) => Promise<MoneyBalance>,
+    getAllBalances: () => Promise<Map<string, MoneyBalance>>
     initUser: (user: string) => Promise<null | void>
 }

--- a/src/types/models/moneybalance.dao.ts
+++ b/src/types/models/moneybalance.dao.ts
@@ -4,9 +4,12 @@ export type MoneyBalance = {
 }
 
 export const MONEY_COLLECTION_NAME = 'moneybalance'
+export const BALANCE_UNINITIALIZED_ERROR = 'BALANCE_NOT_INITIALIZED'
+export const LOW_BALANCE_ERROR = 'LOW_BALANCE'
 
 export type MoneyBalanceDao = {
     getBalance: (user: string) => Promise<MoneyBalance>,
     getAllBalances: () => Promise<Map<string, MoneyBalance>>
     initUser: (user: string) => Promise<null | void>
+    transfer: (from: string, to: string, amount: number) => Promise<null | void>
 }

--- a/src/types/models/pg/moneybalance.ts
+++ b/src/types/models/pg/moneybalance.ts
@@ -6,6 +6,10 @@ function getBalance(user: string): Promise<MoneyBalance> {
     return db.one('SELECT * FROM MoneyBalance WHERE id = $1', [user]);
 }
 
+function getAllBalances(): Promise<Map<string, MoneyBalance>> {
+    throw "NOT IMPLEMENTED"
+}
+
 function initUser(user: string): Promise<null> {
     const db = getPgConnection()
     return db.none('INSERT INTO MoneyBalance VALUES ($1, 100)', [user]);
@@ -13,5 +17,6 @@ function initUser(user: string): Promise<null> {
 
 export const MoneyBalancePgDao : MoneyBalanceDao = {
     getBalance,
+    getAllBalances,
     initUser
 }

--- a/src/types/models/pg/moneybalance.ts
+++ b/src/types/models/pg/moneybalance.ts
@@ -15,8 +15,13 @@ function initUser(user: string): Promise<null> {
     return db.none('INSERT INTO MoneyBalance VALUES ($1, 100)', [user]);
 }
 
+function transfer(from: string, to: string, amount: number): Promise<void> {
+    throw "NOT IMPLEMENTED"
+}
+
 export const MoneyBalancePgDao : MoneyBalanceDao = {
     getBalance,
     getAllBalances,
-    initUser
+    initUser,
+    transfer
 }

--- a/src/types/models/shares.dao.ts
+++ b/src/types/models/shares.dao.ts
@@ -26,6 +26,7 @@ export const LOW_BALANCE_ERROR = 'LOW_BALANCE'
 export const NOT_ENOUGH_SHARES_ERROR = 'NOT_ENOUGH_SHARES'
 
 export type SharesDao = {
+    getAllShares: () => Promise<Map<string, Shares[]>>
     getSharesByUser: (user: string) => Promise<Shares[]>,
     getSharesByUserAndSymbol: (user: string, symbol: string) => Promise<Shares>,
     buyShares: (user: string, symbol: string, amount: number, price: number) => Promise<Transaction>,

--- a/src/types/models/shares.dao.ts
+++ b/src/types/models/shares.dao.ts
@@ -21,8 +21,6 @@ export type Transaction = {
 export const SHARES_COLLECTION_NAME = 'shares'
 export const TRANSACTION_COLLECTION_NAME = 'shares-transactions'
 
-export const BALANCE_UNINITIALIZED_ERROR = 'BALANCE_NOT_INITIALIZED'
-export const LOW_BALANCE_ERROR = 'LOW_BALANCE'
 export const NOT_ENOUGH_SHARES_ERROR = 'NOT_ENOUGH_SHARES'
 
 export type SharesDao = {


### PR DESCRIPTION
`!baltop`

Outputs a table of all users, sorted descending by total combined value of their money and their portfolio. The portfolio value is calculated using cached stock prices. Example output:

```
 Username          | Money    | Portfolio value | Total    
═══════════════════╪══════════╪═════════════════╪══════════
 Chudooder         | 5534.01  | 4498.70         | 10032.71 
 rapp              | 10000.00 | 0.00            | 10000.00 
 tootu4            | 10000.00 | 0.00            | 10000.00 
 DireFireBall      | 10000.00 | 0.00            | 10000.00 
 Bevjaneet         | 10000.00 | 0.00            | 10000.00 
 nofu              | 10000.00 | 0.00            | 10000.00 
 Kim               | 10000.00 | 0.00            | 10000.00 
 SomethingTerrible | 10000.00 | 0.00            | 10000.00 
 ColeMPublic       | 1155.29  | 8819.95         | 9975.24  
 kawAGN            | 86.15    | 9879.60         | 9965.75  
 stampy            | 1.30     | 9857.70         | 9859.00  
 bcrypt            | 60.00    | 9656.00         | 9716.00  
 LaLo              | 250.00   | 9357.00         | 9607.00  
 zh BUeNa          | 5519.20  | 4009.60         | 9528.80  
 BLACK_as_BLACK    | 81.01    | 9269.25         | 9350.26  
 thujaboy          | 48.77    | 9137.45         | 9186.22  
```

`!pay <mentioned-user> <amount>`

Transfers money from the user's balance to the recipient's balance.
